### PR TITLE
Add raider io to the profile links

### DIFF
--- a/Modules/URLHandler.lua
+++ b/Modules/URLHandler.lua
@@ -45,6 +45,10 @@ armoryLinks = {
         title = "Warcraftlogs",
         url = "https://www.warcraftlogs.com/character/{eu/us}/{realm}/{user}"
     },
+	{
+        title = "Raider io",
+        url = "https://raider.io/characters/{eu/us}/{realm}/{user}"
+    },
     {
         title = "WoWTrack",
         url = "https://wowtrack.org/characters/{eu/us}/{realm}/{user}"


### PR DESCRIPTION
Adding raider io to the profile links is usefull, since we/i use raider io alot these days for m+ scoring and this way we/i can quickly access it if someone whispers me.