### PR TITLE
ReglohPri_Deprecated_GuildRoster

### DIFF
--- a/ChangeLog.lua
+++ b/ChangeLog.lua
@@ -80,9 +80,11 @@ local function logSort(a, b)
 end
 
 local changeLogWindow;
+
 local function createChangeLogWindow()
-    -- create frame object
-    local win = CreateFrame("Frame", "WIM3_ChangeLog", _G.UIParent);
+    -- create frame object - changes for Patch 9.0.1 - Shadowlands, retail and classic
+	local win = CreateFrame("Frame", "WIM3_ChangeLog", _G.UIParent, WIM.isShadowlands and "BackdropTemplate");
+
     win:Hide(); -- hide initially, scripts aren't loaded yet.
     table.insert(UISpecialFrames, "WIM3_ChangeLog");
 
@@ -91,11 +93,17 @@ local function createChangeLogWindow()
     win:SetHeight(500);
     win:SetPoint("CENTER");
 
-    -- set backdrop
-    win:SetBackdrop({bgFile = "Interface\\AddOns\\"..WIM.addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
+    -- set backdrop - changes for Patch 9.0.1 - Shadowlands, retail and classic
+    win.backdropInfo = {bgFile = "Interface\\AddOns\\"..WIM.addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
         edgeFile = "Interface\\AddOns\\"..WIM.addonTocName.."\\Sources\\Options\\Textures\\Frame",
         tile = true, tileSize = 64, edgeSize = 64,
-        insets = { left = 64, right = 64, top = 64, bottom = 64 }});
+        insets = { left = 64, right = 64, top = 64, bottom = 64 }};
+
+	if not WIM.isShadowlands then
+		win:SetBackdrop(win.backdropInfo);
+	else
+		win:ApplyBackdrop();
+	end
 
     -- set basic frame properties
     win:SetClampedToScreen(true);

--- a/Modules/ChatEngine.lua
+++ b/Modules/ChatEngine.lua
@@ -265,7 +265,8 @@ end
 
 function Guild:OnWindowShow(self)
     if(self.type == "chat" and self.chatType == "guild") then
-        _G.GuildRoster();
+		-- H.Sch. - ReglohPri - this is deprecated -> GuildRoster() - changed to C_GuildInfo.GuildRoster()
+        _G.C_GuildInfo.GuildRoster();
     end
 end
 

--- a/Modules/ChatEngine.lua
+++ b/Modules/ChatEngine.lua
@@ -1563,15 +1563,24 @@ end
 
 
 local function createUserList()
-    local win = _G.CreateFrame("Frame", "WIM3_ChatUserList", WIM.WindowParent);
+	-- Changes for Patch 9.0.1 - Shadowlands, retail and classic
+	local win = _G.CreateFrame("Frame", "WIM3_ChatUserList", WIM.WindowParent, isShadowlands and "BackdropTemplate");
+
     win:EnableMouse(true);
     win:Hide();
     win:SetPoint("CENTER");
-    -- set backdrop
-    win:SetBackdrop({bgFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu_bg",
+    -- set backdrop - Changes for Patch 9.0.1 - Shadowlands, retail and classic
+    win.backdropInfo = {bgFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu_bg",
         edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu",
         tile = true, tileSize = 32, edgeSize = 32,
-        insets = { left = 32, right = 32, top = 32, bottom = 32 }});
+        insets = { left = 32, right = 32, top = 32, bottom = 32 }};
+
+	if not isShadowlands then
+		win:SetBackdrop(win.backdropInfo);
+	else
+		win:ApplyBackdrop();
+	end
+
     win:SetWidth(200);
     win.title = _G.CreateFrame("Frame", win:GetName().."Title", win);
     win.title:SetHeight(17);

--- a/Modules/Filters.lua
+++ b/Modules/Filters.lua
@@ -416,7 +416,9 @@ end
 -- Options UI
 
 local function createFilterFrame()
-    local win = CreateFrame("Frame", "WIM3_FilterFrame", _G.UIParent);
+	-- Changes for Patch 9.0.1 - Shadowlands, retail and classic
+	local win = CreateFrame("Frame", "WIM3_FilterFrame", _G.UIParent, isShadowlands and "BackdropTemplate");
+
     win:Hide();
     win.filter = {};
     -- set size and position
@@ -424,11 +426,17 @@ local function createFilterFrame()
     win:SetHeight(390);
     win:SetPoint("CENTER");
 
-    -- set backdrop
-    win:SetBackdrop({bgFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
+    -- set backdrop - changes for Patch 9.0.1 - Shadowlands, retail and classic
+    win.backdropInfo = {bgFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
         edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame",
         tile = true, tileSize = 64, edgeSize = 64,
-        insets = { left = 64, right = 64, top = 64, bottom = 64 }});
+        insets = { left = 64, right = 64, top = 64, bottom = 64 }};
+
+	if not isShadowlands then
+		win:SetBackdrop(win.backdropInfo);
+	else
+		win:ApplyBackdrop();
+	end
 
     -- set basic frame properties
     win:SetClampedToScreen(true);
@@ -615,12 +623,22 @@ local function createFilterFrame()
     win.level:SetPoint("RIGHT", -30, 0)
     win.level:Hide();
     options.AddFramedBackdrop(win.level);
-    win.level.slider = CreateFrame("Slider", win.level:GetName().."Slider", win.level);
-    -- set backdrop
-    win.level.slider:SetBackdrop({bgFile = "Interface\\Buttons\\UI-SliderBar-Background",
+
+	-- Changes for Patch 9.0.1 - Shadowlands, retail and classic
+	win.level.slider = CreateFrame("Slider", win.level:GetName().."Slider", win.level, isShadowlands and "BackdropTemplate");
+
+    -- set backdrop - changes for Patch 9.0.1 - Shadowlands, retail and classic
+    win.level.slider.backdropInfo = {bgFile = "Interface\\Buttons\\UI-SliderBar-Background",
         edgeFile = "Interface\\Buttons\\UI-SliderBar-Border",
         tile = true, tileSize = 8, edgeSize = 8,
-        insets = { left = 3, right = 3, top = 6, bottom = 6 }});
+        insets = { left = 3, right = 3, top = 6, bottom = 6 }};
+
+	if not isShadowlands then
+		win.level.slider:SetBackdrop(win.level.slider.backdropInfo);
+	else
+		win.level.slider:ApplyBackdrop();
+	end
+
     win.level.slider:SetHeight(17);
     --win.level.slider:SetPoint("CENTER");
     win.level.slider:SetPoint("TOPLEFT", 20, -30);

--- a/Modules/History.lua
+++ b/Modules/History.lua
@@ -382,7 +382,9 @@ end
 
 
 local function createHistoryViewer()
-    local win = CreateFrame("Frame", "WIM3_HistoryFrame", _G.UIParent);
+	-- Changes for Patch 9.0.1 - Shadowlands, retail and classic
+	local win = CreateFrame("Frame", "WIM3_HistoryFrame", _G.UIParent, isShadowlands and "BackdropTemplate");
+
     win:Hide();
     win.filter = {};
     -- set size and position
@@ -390,11 +392,17 @@ local function createHistoryViewer()
     win:SetHeight(505);
     win:SetPoint("CENTER");
 
-    -- set backdrop
-    win:SetBackdrop({bgFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
+    -- set backdrop - changes for Patch 9.0.1 - Shadowlands
+    win.backdropInfo = {bgFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
         edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame",
         tile = true, tileSize = 64, edgeSize = 64,
-        insets = { left = 64, right = 64, top = 64, bottom = 64 }});
+        insets = { left = 64, right = 64, top = 64, bottom = 64 }};
+
+	if not isShadowlands then
+		win:SetBackdrop(win.backdropInfo);
+	else
+		win:ApplyBackdrop();
+	end
 
     -- set basic frame properties
     win:SetClampedToScreen(true);

--- a/Modules/Menu.lua
+++ b/Modules/Menu.lua
@@ -84,12 +84,12 @@ local function createButton(parent)
     button.text:SetPoint("LEFT"); button.text:SetPoint("RIGHT");
     button:GetHighlightTexture():ClearAllPoints();
     button:GetHighlightTexture():SetAllPoints();
-    
+
     button.status = createStatusIcon(button);
     button.status:SetPoint("LEFT", button, "RIGHT", 0, -1);
     button.close = createCloseButton(button);
     button.close:SetPoint("LEFT", button.status, "RIGHT", 2, 0);
-    
+
     button:SetScript("OnClick", function(self, b)
 			local forceShow = true
 			if db.pop_rules[self.win.type].obeyAutoFocusRules then
@@ -131,12 +131,21 @@ end
 
 local function createGroup(title, list, maxButtons, showNone)
     groupCount = groupCount + 1;
-    local group = CreateFrame("Frame", "WIM3MenuGroup"..groupCount, _G.WIM3Menu);
-    -- set backdrop
-    group:SetBackdrop({bgFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu_bg",
-        edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu", 
-        tile = true, tileSize = 32, edgeSize = 32, 
-        insets = { left = 32, right = 32, top = 32, bottom = 32 }});
+	-- Changes for Patch 9.0.1 - Shadowlands, retail and classic
+	local group = CreateFrame("Frame", "WIM3MenuGroup"..groupCount, _G.WIM3Menu, isShadowlands and "BackdropTemplate");
+
+    -- set backdrop - changes for Patch 9.0.1 - Shadowlands, retail and classic
+    group.backdropInfo = {bgFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu_bg",
+        edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Modules\\Textures\\Menu",
+        tile = true, tileSize = 32, edgeSize = 32,
+        insets = { left = 32, right = 32, top = 32, bottom = 32 }};
+
+	if not isShadowlands then
+		group:SetBackdrop(group.backdropInfo);
+	else
+		group:ApplyBackdrop();
+	end
+
     group.list = list;
     group.title = CreateFrame("Frame", group:GetName().."Title", group);
     group.title:SetHeight(17);
@@ -241,7 +250,7 @@ local function createMenu()
     menu.groups[2] = createGroup(L["Chat"], lists.chat, maxButtons.chat, false);
     menu.groups[2]:SetPoint("TOPLEFT", menu.groups[1], "BOTTOMLEFT", 0, 25);
     menu.groups[2]:SetPoint("TOPRIGHT", menu.groups[1], "BOTTOMRIGHT", 0, 25);
-    
+
     menu.Refresh = function(self)
             local groupHeight = 0;
             local groupWidth = 0;
@@ -253,7 +262,7 @@ local function createMenu()
             self:SetHeight(groupHeight);
             self:SetWidth(groupWidth);
         end
-        
+
     menu:SetScript("OnUpdate", function(self)
             if(isMouseOver()) then
                 self.mouseStamp = _G.time();
@@ -267,7 +276,7 @@ local function createMenu()
             self.mouseStamp = _G.time();
             _G.CloseDropDownMenus();
         end);
-        
+
     return menu;
 end
 

--- a/Sources/Options/Options.lua
+++ b/Sources/Options/Options.lua
@@ -36,21 +36,27 @@ local function getCategoryIndexByName(cat)
 end
 
 local function createOptionsFrame()
-    -- create frame object
-    options.frame = CreateFrame("Frame", "WIM3_Options", _G.UIParent);
+    -- create frame object - changes to Patch 9.0.1 - Shadowlands, retail and classic
+	options.frame = CreateFrame("Frame", "WIM3_Options", _G.UIParent, isShadowlands and "BackdropTemplate");
     local win = options.frame;
     win:Hide(); -- hide initially, scripts aren't loaded yet.
-    
+
     -- set size and position
     win:SetWidth(600);
     win:SetHeight(500);
     win:SetPoint("CENTER");
-    
-    -- set backdrop
-    win:SetBackdrop({bgFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame_Background", 
-        edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame", 
-        tile = true, tileSize = 64, edgeSize = 64, 
-        insets = { left = 64, right = 64, top = 64, bottom = 64 }});
+
+    -- set backdrop - changes to Patch 9.0.1 - Shadowlands, retail and classic
+    win.backdropInfo = {bgFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame_Background",
+        edgeFile = "Interface\\AddOns\\"..addonTocName.."\\Sources\\Options\\Textures\\Frame",
+        tile = true, tileSize = 64, edgeSize = 64,
+        insets = { left = 64, right = 64, top = 64, bottom = 64 }};
+
+	if not isShadowlands then
+		win:SetBackdrop(win.backdropInfo);
+	else
+		win:ApplyBackdrop();
+	end
 
     -- set basic frame properties
     win:SetClampedToScreen(true);
@@ -65,14 +71,14 @@ local function createOptionsFrame()
     win:SetScript("OnHide", function(self) _G.PlaySound(851); options.OnHide(self); end);
     win:SetScript("OnDragStart", function(self) self:StartMoving(); end);
     win:SetScript("OnDragStop", function(self) self:StopMovingOrSizing(); end);
-    
+
     -- create and set title bar text
     win.title = win:CreateFontString(win:GetName().."Title", "OVERLAY", "ChatFontNormal");
     win.title:SetPoint("TOPLEFT", 50 , -20);
     local font = win.title:GetFont();
     win.title:SetFont(font, 16, "");
     win.title:SetText(L["WIM (WoW Instant Messenger)"].." v"..version);
-    
+
     -- create close button
     win.close = CreateFrame("Button", win:GetName().."Close", win);
     win.close:SetWidth(18); win.close:SetHeight(18);
@@ -82,8 +88,8 @@ local function createOptionsFrame()
     win.close:SetScript("OnClick", function(self)
             self:GetParent():Hide();
         end);
-    
-    
+
+
     -- create navigation menu
     win.nav = CreateFrame("Frame", win:GetName().."Nav", win);
     win.nav.bg = win.nav:CreateTexture(win.nav:GetName().."BG", "BACKGROUND");
@@ -100,7 +106,7 @@ local function createOptionsFrame()
     win.nav.sub:Hide();
     win.nav.sub.buttons = {};
     win.nav.sub:SetScript("OnShow", function(self) options.UpdateSubCategories(self); end);
-    
+
     -- create container frame
     win.container = CreateFrame("Frame", win:GetName().."Container", win);
     win.container.bg = win.container:CreateTexture(win.container:GetName().."BG", "BACKGROUND");
@@ -109,7 +115,7 @@ local function createOptionsFrame()
     win.container:SetPoint("TOPLEFT", win.nav, "TOPRIGHT", 10, -2);
     win.container:SetPoint("BOTTOMLEFT", win.nav, "BOTTOMRIGHT", 10, 2);
     win.container:SetPoint("RIGHT", win, -25, 0);
-    
+
     win.Enable = function(self)
         self:SetAlpha(1);
         self.disableFrame:Hide();
@@ -117,7 +123,7 @@ local function createOptionsFrame()
         win:SetFrameStrata("DIALOG");
         win.disableFrame:SetFrameStrata("DIALOG");
     end
-    
+
     win.Disable = function(self)
         self:SetAlpha(.5);
         self.disableFrame:Show();

--- a/Sources/Options/OptionsTookKit.lua
+++ b/Sources/Options/OptionsTookKit.lua
@@ -25,7 +25,7 @@ setfenv(1, WIM);
     - CreateSlider(parent, title, minText, maxText, min, max, step, dbTree, varName, valChanged) returns Slider
     - CreateColorPicker(parent, title, dbTree, varName, valChanged) returns Frame
     - CreateButton(parent, title, fun) returns Button
-    
+
     Frame Modifying Tools:
     - WIM.options.AddFramedBackdrop(theFrame)
 ]]
@@ -125,12 +125,21 @@ end
 
 
 local function CreateSlider(parent, title, minText, maxText, min, max, step, dbTree, varName, valChanged)
-    local s = CreateFrame("Slider", parent:GetName()..statObject("Slider"), parent);
-    -- set backdrop
-    s:SetBackdrop({bgFile = "Interface\\Buttons\\UI-SliderBar-Background", 
-        edgeFile = "Interface\\Buttons\\UI-SliderBar-Border", 
-        tile = true, tileSize = 8, edgeSize = 8, 
-        insets = { left = 3, right = 3, top = 6, bottom = 6 }});
+	-- Changes to Patch 9.0.1 - Shadowlands, retail and classic
+	local s = CreateFrame("Slider", parent:GetName()..statObject("Slider"), parent, isShadowlands and "BackdropTemplate");
+
+    -- set backdrop -changes to Patch 9.0.1 - Shadowlands, retail and classic
+    s.backdropInfo = {bgFile = "Interface\\Buttons\\UI-SliderBar-Background",
+        edgeFile = "Interface\\Buttons\\UI-SliderBar-Border",
+        tile = true, tileSize = 8, edgeSize = 8,
+        insets = { left = 3, right = 3, top = 6, bottom = 6 }};
+
+	if not isShadowlands then
+		s:SetBackdrop(s.backdropInfo);
+	else
+		s:ApplyBackdrop();
+	end
+
     s:SetHeight(17);
     s:SetPoint("LEFT");
     s:SetPoint("RIGHT", -75, 0);
@@ -152,7 +161,7 @@ local function CreateSlider(parent, title, minText, maxText, min, max, step, dbT
     s.valText:SetText("");
     s:SetValueStep(step);
     s:SetScript("OnValueChanged", function(self)
-        if not self._onsetting then   -- is single threaded 
+        if not self._onsetting then   -- is single threaded
             self._onsetting = true
             self:SetValue(self:GetValue())
             value = self:GetValue()     -- cant use original 'value' parameter
@@ -284,7 +293,7 @@ local function CreateCheckButton(parent, title, dbTree, varName, tooltip, valCha
                 end
             end
         end
-        
+
     if(parent.isCheckButton) then
         cb:SetScale(.90);
         if(#parent.children == 0) then
@@ -312,17 +321,17 @@ local function CreateCheckButtonMenu(parent, title, dbTree, varName, tooltip, va
     cbm.menu:SetPoint("LEFT", cbm:GetWidth()-2, 0);
     cbm.menu.itemList = itemList;
     cbm.menu.dropdown = options.createDropDownFrame();
-    
+
     cbm.text:ClearAllPoints(); cbm.text:SetPoint("LEFT", cbm.menu, "RIGHT");
     -- some hooks to enherit disabled functionality.
     local Enable, Disable = cbm.Enable, cbm.Disable;
     cbm.Enable = function(...) cbm.menu:Enable(); Enable(...); end
     cbm.Disable = function(...) cbm.menu:Disable();  Disable(...); end
-    
+
     local function clickFunc(self, ...)
         dbTree2[varName2] = self.value;
     end
-    
+
     -- now the menu work...
     cbm.menu:SetScript("OnClick", function(self, button)
             _G.PlaySound(1115);
@@ -478,31 +487,31 @@ local function setButton(self, info)
     self:ClearButton();
     local invisibleButton = _G[self:GetName().."InvisibleButton"];
     local normalText = _G[self:GetName().."NormalText"];
-    
+
     -- set default values
     self:Enable();
     self:SetDisabledFontObject(_G.GameFontDisableSmallLeft);
     invisibleButton:Hide();
-    
+
     -- If not clickable then disable the button and set it white
 	if ( info.notClickable ) then
 		info.disabled = 1;
 		self:SetDisabledFontObject(_G.GameFontHighlightSmallLeft);
 	end
-        
+
     -- Set the text color and disable it if its a title
 	if ( info.isTitle ) then
 		info.disabled = 1;
 		self:SetDisabledFontObject(_G.GameFontNormalSmallLeft);
 	end
-        
+
     -- Disable the button if disabled and turn off the color code
 	if ( info.disabled ) then
 		self:Disable();
 		invisibleButton:Show();
 		info.colorCode = nil;
 	end
-    
+
     self:SetText(info.text or "");
 
     -- Pass through attributes
@@ -522,9 +531,9 @@ local function setButton(self, info)
 	else
 		self.value = nil;
 	end
-        
+
         local checked = info.checked;
-        
+
         -- If not checkable move everything over to the left to fill in the gap where the check would be
 	normalText:ClearAllPoints();
 	if ( info.notCheckable ) then
@@ -539,7 +548,7 @@ local function setButton(self, info)
                     checked = true;
                 end
 	end
-        
+
     -- Checked can be a function now
 	if ( type(checked) == "function" ) then
 		checked = checked();
@@ -572,25 +581,35 @@ function options.createDropDownFrame()
         -- don't create more than once.
         return dropDownFrame;
     end
-    local f = CreateFrame("Button", "WIM_DropDownFrame", _G.UIParent);
-    f:Hide();
+	-- Changes to Patch 9.0.1 - Shadowlands, retail and classic
+	local f = CreateFrame("Button", "WIM_DropDownFrame", _G.UIParent, isShadowlands and "BackdropTemplate");
+
+	f:Hide();
     f:SetFrameStrata("TOOLTIP");
     f:SetPoint("CENTER");
     f:SetWidth(100);
     f:SetHeight(300);
     f:EnableMouseWheel(1);
-    f:SetBackdrop( { 
-        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background", 
-        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", tile = true, tileSize = 16, edgeSize = 16, 
+	-- Changes to Patch 9.0.1 - Shadowlands, retail and classic
+    f.backdropInfo = {
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border", tile = true, tileSize = 16, edgeSize = 16,
         insets = { left = 5, right = 5, top = 5, bottom = 5 }
-    });
+    };
+
+	if not isShadowlands then
+		f:SetBackdrop(f.backdropInfo);
+	else
+		f:ApplyBackdrop();
+	end
+
     f:SetBackdropBorderColor(_G.TOOLTIP_DEFAULT_COLOR.r, _G.TOOLTIP_DEFAULT_COLOR.g, _G.TOOLTIP_DEFAULT_COLOR.b);
     f:SetBackdropColor(_G.TOOLTIP_DEFAULT_BACKGROUND_COLOR.r, _G.TOOLTIP_DEFAULT_BACKGROUND_COLOR.g, _G.TOOLTIP_DEFAULT_BACKGROUND_COLOR.b);
-    
+
     f.testString = f:CreateFontString(f:GetName().."TestString", "OVERLAY", "GameFontNormalSmallLeft");
     f.testString:SetPoint("TOPLEFT");
     f.testString:Hide();
-    
+
     --create scroll bar
     f.scroll = CreateFrame("Slider", f:GetName().."Slider", f);
     f.scroll.bg = f.scroll:CreateTexture(nil, "BACKGROUND");
@@ -612,7 +631,7 @@ function options.createDropDownFrame()
     f.scroll:SetScript("OnValueChanged", function(self)
         self:GetParent():Refresh();
     end);
-    
+
     -- create buttons
     f.buttons = {};
     for i=1, dropDownButtonCount do
@@ -636,7 +655,7 @@ function options.createDropDownFrame()
             end
         end);
     end
-    
+
     -- actions
     f.ClearButtons = clearButtons;
     -- this call is made to reconfigure buttons.
@@ -666,7 +685,7 @@ function options.createDropDownFrame()
         -- set appropriate height
         self.buttonsShown = _G.math.min(#self.list, #self.buttons);
         self:SetHeight((self.buttonsShown * self.buttons[1]:GetHeight()) + 18);
-        
+
         -- set appropriate width
         local maxWidth, tIndex = 20;
         for index, tbl in pairs(self.list) do
@@ -686,11 +705,11 @@ function options.createDropDownFrame()
                 self.buttons[i]:Show();
             end
         end
-        
+
         self:Refresh();
         return self; -- allow for Chained actions;
     end
-    
+
     f.ToggleDropDownMenu = function(self, parent, point, relativePoint, xOffset, yOffset)
         if(f.prevParent == parent) then
             f.prevParent = nil;
@@ -711,7 +730,7 @@ function options.createDropDownFrame()
         f.prevParent = parent;
         f:Show();
     end
-    
+
     f:SetScript("OnClick", function(self) self:Hide(); end);
     f:SetScript("OnEnter", _G.UIDropDownMenu_StopCounting);
     f:SetScript("OnLeave", _G.UIDropDownMenu_StartCounting);
@@ -721,7 +740,7 @@ function options.createDropDownFrame()
         self.prevParent = nil;
     end);
     f:SetScript("OnMouseWheel", DropDown_OnMouseWheel);
-    
+
     dropDownFrame = f;
     return f;
 end

--- a/WIM.lua
+++ b/WIM.lua
@@ -19,6 +19,7 @@ version = "@project-version@";
 beta = false; -- flags current version as beta.
 debug = false; -- turn debugging on and off.
 useProtocol2 = true; -- test switch for new W2W Protocol. (Dev use only)
+isShadowlands = (select(4, _G.GetBuildInfo()) >= 90000);
 
 -- is Private Server?
 --[[isPrivateServer = not (string.match(_G.GetCVar("realmList"), "worldofwarcraft.com$")

--- a/WIM.lua
+++ b/WIM.lua
@@ -80,7 +80,8 @@ local function initialize()
 
         --querie guild roster
         if( _G.IsInGuild() ) then
-            _G.GuildRoster();
+			-- H.Sch. - ReglohPri - this is deprecated -> GuildRoster() - changed to C_GuildInfo.GuildRoster()
+            _G.C_GuildInfo.GuildRoster();
         end
 
     -- import libraries.


### PR DESCRIPTION
Since Patch 8.2.0 is GuildRoster() deprecated.
I changed it to C_GuildInfo.GuildRoster().

Tested on the PTR Server for Shadowlands.
I'm not sure if it works under classic

Merge first my Patches for 9.0.1 and then this here.